### PR TITLE
Update seek branch with latest changes from upstream v1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+version: 2.1
+
+references:
+  images:
+    go: &GOLANG_IMAGE circleci/golang:latest
+
+# reusable 'executor' object for jobs
+executors:
+  go:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      - TEST_RESULTS: /tmp/test-results # path to where test results are saved
+
+jobs:
+  go-fmt-and-vet:
+    executor: go
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - go-immutable-radix-modcache-v1-{{ checksum "go.mod" }}
+
+      - run: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: go-immutable-radix-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
+
+      # check go fmt output because it does not report non-zero when there are fmt changes
+      - run:
+          name: check go fmt
+          command: |
+            files=$(go fmt ./...)
+            if [ -n "$files" ]; then
+              echo "The following file(s) do not conform to go fmt:"
+              echo "$files"
+              exit 1
+            fi
+      - run: go vet ./...
+
+  go-test:
+    executor: go
+    steps:
+      - checkout
+      - run: mkdir -p $TEST_RESULTS
+
+      - restore_cache: # restore cache from dev-build job
+          keys:
+            - go-immutable-radix-modcache-v1-{{ checksum "go.mod" }}
+
+      # run go tests with gotestsum
+      - run: |
+          PACKAGE_NAMES=$(go list ./...)
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS/gotestsum-report.xml -- $PACKAGE_NAMES
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+workflows:
+  version: 2
+  test-and-build:
+    jobs:
+      - go-fmt-and-vet
+      - go-test:
+          requires:
+            - go-fmt-and-vet

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: go
-go:
-  - tip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# UNRELEASED
+
+FEATURES
+
+* Add `SeekLowerBound` to allow for range scans. [[GH-24](https://github.com/hashicorp/go-immutable-radix/pull/24)]
+
+# 1.0.0 (August 30th, 2018)
+
+* go mod adopted

--- a/README.md
+++ b/README.md
@@ -39,3 +39,28 @@ if string(m) != "foo" {
 }
 ```
 
+Here is an example of performing a range scan of the keys.
+
+```go
+// Create a tree
+r := iradix.New()
+r, _, _ = r.Insert([]byte("001"), 1)
+r, _, _ = r.Insert([]byte("002"), 2)
+r, _, _ = r.Insert([]byte("005"), 5)
+r, _, _ = r.Insert([]byte("010"), 10)
+r, _, _ = r.Insert([]byte("100"), 10)
+
+// Range scan over the keys that sort lexicographically between [003, 050)
+it := r.Root().Iterator()
+it.SeekLowerBound([]byte("003"))
+for key, _, ok := it.Next(); ok; key, _, ok = it.Next() {
+  if key >= "050" {
+      break
+  }
+  fmt.Println(key)
+}
+// Output:
+//  005
+//  010
+```
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-go-immutable-radix [![Build Status](https://travis-ci.org/hashicorp/go-immutable-radix.png)](https://travis-ci.org/hashicorp/go-immutable-radix)
+go-immutable-radix [![CircleCI](https://circleci.com/gh/hashicorp/go-immutable-radix/tree/master.svg?style=svg)](https://circleci.com/gh/hashicorp/go-immutable-radix/tree/master)
 =========
 
 Provides the `iradix` package that implements an immutable [radix tree](http://en.wikipedia.org/wiki/Radix_tree).

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/hashicorp/go-immutable-radix
+
+require (
+	github.com/hashicorp/go-uuid v1.0.0
+	github.com/hashicorp/golang-lru v0.5.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/iradix.go
+++ b/iradix.go
@@ -338,6 +338,11 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if !n.isLeaf() {
 			return nil, nil
 		}
+		// Copy the pointer in case we are in a transaction that already
+		// modified this node since the node will be reused. Any changes
+		// made to the node will not affect returning the original leaf
+		// value.
+		oldLeaf := n.leaf
 
 		// Remove the leaf node
 		nc := t.writeNode(n, true)
@@ -347,7 +352,7 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if n != t.root && len(nc.edges) == 1 {
 			t.mergeChild(nc)
 		}
-		return nc, n.leaf
+		return nc, oldLeaf
 	}
 
 	// Look for an edge

--- a/iradix.go
+++ b/iradix.go
@@ -86,6 +86,20 @@ func (t *Tree) Txn() *Txn {
 	return txn
 }
 
+// Clone makes an independent copy of the transaction. The new transaction
+// does not track any nodes and has TrackMutate turned off.
+func (t *Txn) Clone() *Txn {
+	// reset the writable node cache to avoid leaking future writes into the clone
+	t.writable = nil
+
+	txn := &Txn{
+		root: t.root,
+		snap: t.snap,
+		size: t.size,
+	}
+	return txn
+}
+
 // TrackMutate can be used to toggle if mutations are tracked. If this is enabled
 // then notifications will be issued for affected internal nodes and leaves when
 // the transaction is committed.

--- a/iradix.go
+++ b/iradix.go
@@ -87,7 +87,7 @@ func (t *Tree) Txn() *Txn {
 }
 
 // Clone makes an independent copy of the transaction. The new transaction
-// does not track any nodes and has TrackMutate turned off.
+// does not track any nodes and has TrackMutate turned off. The cloned transaction will contain any uncommitted writes in the original transaction but further mutations to either will be independent and result in different radix trees on Commit. A cloned transaction may be passed to another goroutine and mutated there independently however each transaction may only be mutated in a single thread.
 func (t *Txn) Clone() *Txn {
 	// reset the writable node cache to avoid leaking future writes into the clone
 	t.writable = nil

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/uuid"
+	"github.com/hashicorp/go-uuid"
 )
 
 func CopyTree(t *Tree) *Tree {
@@ -55,7 +55,10 @@ func TestRadix_HugeTxn(t *testing.T) {
 	txn1 := r.Txn()
 	var expect []string
 	for i := 0; i < defaultModifiedCache*100; i++ {
-		gen := uuid.GenerateUUID()
+		gen, err := uuid.GenerateUUID()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 		txn1.Insert([]byte(gen), i)
 		expect = append(expect, gen)
 	}
@@ -85,7 +88,10 @@ func TestRadix(t *testing.T) {
 	var min, max string
 	inp := make(map[string]interface{})
 	for i := 0; i < 1000; i++ {
-		gen := uuid.GenerateUUID()
+		gen, err := uuid.GenerateUUID()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 		inp[gen] = i
 		if gen < min || i == 0 {
 			min = gen

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1774,3 +1774,33 @@ func TestIterateLowerBoundFuzz(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestClone(t *testing.T) {
+	r := New()
+
+	t1 := r.Txn()
+	t1.Insert([]byte("foo"), 7)
+	t2 := t1.Clone()
+
+	t1.Insert([]byte("bar"), 42)
+	t2.Insert([]byte("baz"), 43)
+
+	if val, ok := t1.Get([]byte("foo")); !ok || val != 7 {
+		t.Fatalf("bad foo in t1")
+	}
+	if val, ok := t2.Get([]byte("foo")); !ok || val != 7 {
+		t.Fatalf("bad foo in t2")
+	}
+	if val, ok := t1.Get([]byte("bar")); !ok || val != 42 {
+		t.Fatalf("bad bar in t1")
+	}
+	if _, ok := t2.Get([]byte("bar")); ok {
+		t.Fatalf("bar found in t2")
+	}
+	if _, ok := t1.Get([]byte("baz")); ok {
+		t.Fatalf("baz found in t1")
+	}
+	if val, ok := t2.Get([]byte("baz")); !ok || val != 43 {
+		t.Fatalf("bad baz in t2")
+	}
+}

--- a/iradix_test.go
+++ b/iradix_test.go
@@ -1724,8 +1724,8 @@ func TestIterateLowerBoundFuzz(t *testing.T) {
 	r := New()
 	set := []string{}
 
-	// This species a property where each call adds a new random key to the radix
-	// tree (with a null byte appended since out tree doesn't support one key
+	// This specifies a property where each call adds a new random key to the radix
+	// tree (with a null byte appended since our tree doesn't support one key
 	// being a prefix of another and treats null bytes specially).
 	//
 	// It also maintains a plain sorted list of the same set of keys and asserts

--- a/iter.go
+++ b/iter.go
@@ -88,7 +88,7 @@ func (i *Iterator) SeekLowerBound(key []byte) {
 	}
 
 	for {
-		// Compare current prefix with the seaarch key's same-length prefix.
+		// Compare current prefix with the search key's same-length prefix.
 		var prefixCmp int
 		if len(n.prefix) < len(search) {
 			prefixCmp = bytes.Compare(n.prefix, search[0:len(n.prefix)])

--- a/iter.go
+++ b/iter.go
@@ -1,6 +1,8 @@
 package iradix
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // Iterator is used to iterate over a set of nodes
 // in pre-order
@@ -51,6 +53,69 @@ func (i *Iterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
 // SeekPrefix is used to seek the iterator to a given prefix
 func (i *Iterator) SeekPrefix(prefix []byte) {
 	i.SeekPrefixWatch(prefix)
+}
+
+// SeekLowerBound is used to seek the iterator to the smallest key that is
+// greater or equal to the given key. There is no watch variant as it's hard to
+// predict based on the radix structure which node(s) changes might affect the
+// result.
+func (i *Iterator) SeekLowerBound(key []byte) {
+	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
+	// go because we need only a subset of edges of many nodes in the path to the
+	// leaf with the lower bound.
+	i.stack = []edges{}
+	n := i.node
+	search := key
+
+	found := func(n *Node) {
+		i.node = n
+		i.stack = append(i.stack, edges{edge{node: n}})
+	}
+
+	for {
+		// Consume the search prefix
+		if len(n.prefix) > len(search) {
+			search = []byte{}
+		} else {
+			search = search[len(n.prefix):]
+		}
+
+		// Is this a leaf? If so check if it's lower than the key (no lower bound
+		// exists).
+		if n.leaf != nil {
+			if bytes.Compare(n.leaf.key, key) < 0 {
+				i.node = nil
+				return
+			}
+
+			// We are a leaf that is greater or equal, that means we are the lower
+			// bound.
+			found(n)
+			return
+		}
+
+		// Check for key exhaustion
+		if len(search) == 0 {
+			found(n)
+			return
+		}
+
+		// Not a leaf, look for the lower bound edge
+		idx, lbNode := n.getLowerBoundEdge(search[0])
+		if lbNode == nil {
+			i.node = nil
+			return
+		}
+
+		// Create stack edges for the all strictly higher edges in this node.
+		if idx+1 < len(n.edges) {
+			i.stack = append(i.stack, n.edges[idx+1:])
+		}
+
+		i.node = lbNode
+		// Recurse
+		n = lbNode
+	}
 }
 
 // Next returns the next node in order

--- a/node.go
+++ b/node.go
@@ -79,6 +79,18 @@ func (n *Node) getEdge(label byte) (int, *Node) {
 	return -1, nil
 }
 
+func (n *Node) getLowerBoundEdge(label byte) (int, *Node) {
+	num := len(n.edges)
+	idx := sort.Search(num, func(i int) bool {
+		return n.edges[i].label >= label
+	})
+	// we want lower bound behavior so return even if it's not an exact match
+	if idx < num {
+		return idx, n.edges[idx].node
+	}
+	return -1, nil
+}
+
 func (n *Node) delEdge(label byte) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {


### PR DESCRIPTION
full diff: https://github.com/hashicorp/go-immutable-radix/compare/8aac2701530899b64bdea735a1de8da899815220...v1.2.0

supersedes https://github.com/tonistiigi/go-immutable-radix/pull/1
closes https://github.com/tonistiigi/go-immutable-radix/pull/1


### Changes from v1.0.0

https://github.com/hashicorp/go-immutable-radix/compare/8aac2701530899b64bdea735a1de8da899815220...v1.0.0

- hashicorp/go-immutable-radix/pull/15 Fix Len() when deleting keys in a transaction
- add go.mod

### Changes from v1.1.0

https://github.com/hashicorp/go-immutable-radix/compare/v1.0.0...v1.1.0

- Add LowerBound to allow range scans

### Changes from v1.2.0

https://github.com/hashicorp/go-immutable-radix/compare/v1.1.0...v1.2.0

- Added Clone method to Txn to create an independent copy of a transaction


